### PR TITLE
Update to include a reset for strokeWeight(1)

### DIFF
--- a/03_Draw/Example_03_12.js
+++ b/03_Draw/Example_03_12.js
@@ -10,4 +10,5 @@ function draw() {
   ellipse(279, 60, 90, 90);
   strokeWeight(20);  // Stroke weight to 20 pixels
   ellipse(389, 60, 90, 90);
+  strokeWeight(1); // Reset stroke to default value preceding next loop
 }


### PR DESCRIPTION
The photo in the book does not match what the previous code produces. I've added a line at the end to reset the stroke value to 1.