### PR TITLE
Fixed code in Example 3-12

### DIFF
--- a/03_Draw/Example_03_12.js
+++ b/03_Draw/Example_03_12.js
@@ -4,6 +4,7 @@ function setup() {
 
 function draw() {
   background(204);
+  strokeWeight(1); // Stroke weight to 1 pixel
   ellipse(75, 60, 90, 90);
   strokeWeight(8);  // Stroke weight to 8 pixels
   ellipse(175, 60, 90, 90);


### PR DESCRIPTION
The code as it is renders the leftmost ellipse with a strokeWeight of 20, as draw() is continuously called and without an exit(). While exit() is one solution, the other, given that readers haven't been introduced to the method by this stage, would be to set the strokeWeight(1) for the first ellipse.